### PR TITLE
Add update_warning functionality

### DIFF
--- a/src/modules/update_warning/app/update_warning_controller.py
+++ b/src/modules/update_warning/app/update_warning_controller.py
@@ -1,5 +1,11 @@
+from urllib3 import request
 from src.modules.update_warning.app.update_warning_usecase import UpdateWarningUsecase
+from src.modules.update_warning.app.update_warning_viewmodel import UpdateWarningViewmodel
+from src.shared.helpers.errors.controller_errors import MissingParameters, WrongTypeParameter
+from src.shared.helpers.errors.domain_errors import EntityError
+from src.shared.helpers.errors.usecase_errors import DuplicatedItem, ForbiddenAction, NoItemsFound
 from src.shared.helpers.external_interfaces.external_interface import IRequest, IResponse
+from src.shared.helpers.external_interfaces.http_codes import OK, BadRequest, Conflict, Forbidden, InternalServerError, NotFound
 
 
 class UpdateWarningController:
@@ -7,25 +13,62 @@ class UpdateWarningController:
         self.usecase= usecase
 
     def __call__(self, request: IRequest) -> IResponse:
-        warning_id = request.data.get('warning_id')
+        try:
+            requester_user = request.data.get('user_from_authorizer')
 
-        title = request.data.get('title')
-        description = request.data.get('description')
-        expire = request.data.get('expire')
-        target_role = request.data.get('target_role')
-        target_org = request.data.get('target_org')
+            if requester_user is None:
+                    raise MissingParameters('user_from_authorizer')
 
-        requester_user = request.data.get('user_from_authorizer')
-        requester_user_id = requester_user.get('id') if requester_user else None
+            requester_user_id = requester_user.get('id') if requester_user else None
 
-        updated_warning = self.usecase(
-            warning_id=warning_id,
-            title=title,
-            description=description,
-            expire=expire,
-            target_role=target_role,
-            user_id=requester_user_id,
-            target_org=target_org
-        )
+            update_warning = request.data.get('update_warning')
+            if update_warning is None:
+                raise MissingParameters('update_warning')
+            
+            warning_id = update_warning.get('warning_id')
+            if warning_id is None:
+                raise MissingParameters('warning_id')
+            
+            updated_warning = update_warning.get('updated_warning')
+            if updated_warning is None:
+                raise MissingParameters('updated_warning')
+            
+            title = updated_warning.get('title')
+            description = updated_warning.get('description')
+            expire = updated_warning.get('expire')
+            target_role = updated_warning.get('target_role')
+            target_org = updated_warning.get('target_org')
 
-        return updated_warning
+            updated_warning = self.usecase(
+                warning_id=warning_id,
+                title=title,
+                description=description,
+                expire=expire,
+                target_role=target_role,
+                user_id=requester_user_id,
+                target_org=target_org
+            )
+
+            viewmodel = UpdateWarningViewmodel(updated_warning)
+            return OK(body=viewmodel.to_dict())
+    
+        except NoItemsFound as err:
+            return NotFound(body=err.message)
+        
+        except DuplicatedItem as err:
+            return Conflict(body=err.message)
+
+        except MissingParameters as err:
+            return BadRequest(body=err.message)
+
+        except WrongTypeParameter as err:
+            return BadRequest(body=err.message)
+
+        except EntityError as err:
+            return BadRequest(body=err.message)
+        
+        except ForbiddenAction as err:
+            return Forbidden(body=err.message)
+
+        except Exception as err:
+            return InternalServerError(body=err.args[0])

--- a/src/modules/update_warning/app/update_warning_controller.py
+++ b/src/modules/update_warning/app/update_warning_controller.py
@@ -1,6 +1,6 @@
 from urllib3 import request
-from src.modules.update_warning.app.update_warning_usecase import UpdateWarningUsecase
-from src.modules.update_warning.app.update_warning_viewmodel import UpdateWarningViewmodel
+from .update_warning_usecase import UpdateWarningUsecase
+from .update_warning_viewmodel import UpdateWarningViewmodel
 from src.shared.helpers.errors.controller_errors import MissingParameters, WrongTypeParameter
 from src.shared.helpers.errors.domain_errors import EntityError
 from src.shared.helpers.errors.usecase_errors import DuplicatedItem, ForbiddenAction, NoItemsFound

--- a/src/modules/update_warning/app/update_warning_controller.py
+++ b/src/modules/update_warning/app/update_warning_controller.py
@@ -1,0 +1,31 @@
+from src.modules.update_warning.app.update_warning_usecase import UpdateWarningUsecase
+from src.shared.helpers.external_interfaces.external_interface import IRequest, IResponse
+
+
+class UpdateWarningController:
+    def __init__(self, usecase: UpdateWarningUsecase):
+        self.usecase= usecase
+
+    def __call__(self, request: IRequest) -> IResponse:
+        warning_id = request.data.get('warning_id')
+
+        title = request.data.get('title')
+        description = request.data.get('description')
+        expire = request.data.get('expire')
+        target_role = request.data.get('target_role')
+        target_org = request.data.get('target_org')
+
+        requester_user = request.data.get('user_from_authorizer')
+        requester_user_id = requester_user.get('id') if requester_user else None
+
+        updated_warning = self.usecase(
+            warning_id=warning_id,
+            title=title,
+            description=description,
+            expire=expire,
+            target_role=target_role,
+            user_id=requester_user_id,
+            target_org=target_org
+        )
+
+        return updated_warning

--- a/src/modules/update_warning/app/update_warning_controller.py
+++ b/src/modules/update_warning/app/update_warning_controller.py
@@ -1,6 +1,6 @@
 from urllib3 import request
-from .update_warning_usecase import UpdateWarningUsecase
-from .update_warning_viewmodel import UpdateWarningViewmodel
+from src.modules.update_warning.app.update_warning_usecase import UpdateWarningUsecase
+from src.modules.update_warning.app.update_warning_viewmodel import UpdateWarningViewmodel
 from src.shared.helpers.errors.controller_errors import MissingParameters, WrongTypeParameter
 from src.shared.helpers.errors.domain_errors import EntityError
 from src.shared.helpers.errors.usecase_errors import DuplicatedItem, ForbiddenAction, NoItemsFound

--- a/src/modules/update_warning/app/update_warning_presenter.py
+++ b/src/modules/update_warning/app/update_warning_presenter.py
@@ -1,6 +1,6 @@
 import json
-from src.modules.update_warning.app.update_warning_controller import UpdateWarningController
-from src.modules.update_warning.app.update_warning_usecase import UpdateWarningUsecase
+from .update_warning_controller import UpdateWarningController
+from .update_warning_usecase import UpdateWarningUsecase
 from src.shared.environments import Environments
 from src.shared.helpers.external_interfaces.http_lambda_requests import LambdaHttpRequest, LambdaHttpResponse
 

--- a/src/modules/update_warning/app/update_warning_presenter.py
+++ b/src/modules/update_warning/app/update_warning_presenter.py
@@ -1,0 +1,42 @@
+import json
+from src.modules.update_warning.app.update_warning_controller import UpdateWarningController
+from src.modules.update_warning.app.update_warning_usecase import UpdateWarningUsecase
+from src.shared.environments import Environments
+from src.shared.helpers.external_interfaces.http_lambda_requests import LambdaHttpRequest, LambdaHttpResponse
+
+
+repo= Environments.warning_repo()
+user_repo= Environments.get_user_repo()
+
+usecase= UpdateWarningUsecase(repo, user_repo)
+controller= UpdateWarningController(usecase)
+
+def lambda_handler(event, context):
+    httpRequest= LambdaHttpRequest(data=event)
+
+    user_graph_info_raw = (
+        event.get("requestContext", {})
+             .get("authorizer", {})
+             .get("user")
+    )
+
+    user_info = None
+    if isinstance(user_graph_info_raw, str):
+        try:
+            user_info = json.loads(user_graph_info_raw)
+        except json.JSONDecodeError:
+            user_info = None
+    elif isinstance(user_graph_info_raw, dict):
+        user_info = user_graph_info_raw
+
+    httpRequest.data["user_from_authorizer"] = user_info
+
+    response= controller(httpRequest)
+    httpResponse= LambdaHttpResponse(
+        status_code= response.status_code,
+        body= response.body,
+        headers= response.headers
+    )
+
+    return httpResponse.toDict()
+

--- a/src/modules/update_warning/app/update_warning_presenter.py
+++ b/src/modules/update_warning/app/update_warning_presenter.py
@@ -1,6 +1,6 @@
 import json
-from .update_warning_controller import UpdateWarningController
-from .update_warning_usecase import UpdateWarningUsecase
+from src.modules.update_warning.app.update_warning_controller import UpdateWarningController
+from src.modules.update_warning.app.update_warning_usecase import UpdateWarningUsecase
 from src.shared.environments import Environments
 from src.shared.helpers.external_interfaces.http_lambda_requests import LambdaHttpRequest, LambdaHttpResponse
 

--- a/src/modules/update_warning/app/update_warning_usecase.py
+++ b/src/modules/update_warning/app/update_warning_usecase.py
@@ -58,9 +58,9 @@ class UpdateWarningUsecase:
             eb_client= EventBridgeClient()
             expire_timestamp_ms = expire
             
-            eb_client.create_trigger_for_deletion(
-                warning_id=warning.warning_id,
-                expire=expire_timestamp_ms
+            eb_client.update_trigger_expiration(
+                warning_id=warning_id,
+                expire_timestamp_ms=expire_timestamp_ms
             )
 
         updated_warning = self.repo.update_warning(warning_id, warning)

--- a/src/modules/update_warning/app/update_warning_usecase.py
+++ b/src/modules/update_warning/app/update_warning_usecase.py
@@ -58,9 +58,9 @@ class UpdateWarningUsecase:
             eb_client= EventBridgeClient()
             expire_timestamp_ms = expire
             
-            eb_client.update_trigger_expiration(
-                warning_id=warning_id,
-                expire_timestamp_ms=expire_timestamp_ms
+            eb_client.create_trigger_for_deletion(
+                warning_id=warning.warning_id,
+                expire=expire_timestamp_ms
             )
 
         updated_warning = self.repo.update_warning(warning_id, warning)

--- a/src/modules/update_warning/app/update_warning_usecase.py
+++ b/src/modules/update_warning/app/update_warning_usecase.py
@@ -1,0 +1,66 @@
+from src.shared.clients.event_bridge_client import EventBridgeClient
+from src.shared.domain.enums.role_enum import ROLE
+from src.shared.domain.repositories.user_repository_interface import IUserRepository
+from src.shared.domain.repositories.warning_repository_interface import IWarningRepository
+from src.shared.domain.entities.warning import Warning, WarningBody
+from src.shared.environments import Environments
+from src.shared.helpers.errors.usecase_errors import ForbiddenAction
+
+class UpdateWarningUsecase:
+    def __init__(self, repo: IWarningRepository, user_repo: IUserRepository):
+        self.repo = repo
+        self.user_repo = user_repo
+
+    def __call__(
+        self,
+        warning_id: str,
+
+        title: str | None,
+        description: str | None,
+        expire: int | None,
+        target_role: str | None,
+        user_id: str | None,
+        target_org=None | None) -> Warning:
+        
+        if self.user_repo.get_user(user_id=user_id).role != ROLE.ADM:
+            raise ForbiddenAction("Only ADM users can create warnings.")
+        
+        original_warning = self.repo.get_warning(warning_id)
+    
+        if target_org:
+            body= WarningBody(
+                title=title if title else original_warning.body.title,
+                description=description if description else original_warning.body.description,
+                expire=expire if expire else original_warning.body.expire
+            )
+
+            warning= Warning(
+                warning_id=warning_id,
+                target_role=target_role if target_role else original_warning.target_role,
+                target_org=target_org if target_org else original_warning.target_org,
+                body=body
+            )
+        else:
+            body= WarningBody(
+                title=title if title else original_warning.body.title,
+                description=description if description else original_warning.body.description,
+                expire=expire if expire else original_warning.body.expire
+            )
+
+            warning= Warning(
+                warning_id=warning_id ,
+                target_role=target_role if target_role else original_warning.target_role,
+                body=body
+            )
+        
+        if not Environments.get_envs().stage.value == "TEST" and original_warning.body.expire != expire:
+            eb_client= EventBridgeClient()
+            expire_timestamp_ms = expire
+            
+            eb_client.create_trigger_for_deletion(
+                warning_id=warning.warning_id,
+                expire=expire_timestamp_ms
+            )
+
+        updated_warning = self.repo.update_warning(warning_id, warning)
+        return updated_warning

--- a/src/modules/update_warning/app/update_warning_usecase.py
+++ b/src/modules/update_warning/app/update_warning_usecase.py
@@ -58,7 +58,7 @@ class UpdateWarningUsecase:
             eb_client= EventBridgeClient()
             expire_timestamp_ms = expire
             
-            eb_client.create_trigger_for_deletion(
+            eb_client.update_trigger_expiration(
                 warning_id=warning.warning_id,
                 expire=expire_timestamp_ms
             )

--- a/src/modules/update_warning/app/update_warning_usecase.py
+++ b/src/modules/update_warning/app/update_warning_usecase.py
@@ -17,13 +17,13 @@ class UpdateWarningUsecase:
 
         title: str | None,
         description: str | None,
-        expire: int | None,
-        target_role: str | None,
         user_id: str | None,
-        target_org=None | None) -> Warning:
+        expire: int | None = None,
+        target_role: str | None = None,
+        target_org: str | None = None) -> Warning:
         
         if self.user_repo.get_user(user_id=user_id).role != ROLE.ADM:
-            raise ForbiddenAction("Only ADM users can create warnings.")
+            raise ForbiddenAction("Only ADM users can update warnings.")
         
         original_warning = self.repo.get_warning(warning_id)
     
@@ -50,6 +50,7 @@ class UpdateWarningUsecase:
             warning= Warning(
                 warning_id=warning_id ,
                 target_role=target_role if target_role else original_warning.target_role,
+                target_org=original_warning.target_org,
                 body=body
             )
         

--- a/src/modules/update_warning/app/update_warning_viewmodel.py
+++ b/src/modules/update_warning/app/update_warning_viewmodel.py
@@ -6,7 +6,7 @@ class UpdateWarningViewmodel:
 
     def to_dict(self):
         return {
-            "updated-warning": {
+            "updated_warning": {
                 "warning_id": self.warning.warning_id,
                 "target_role": self.warning.target_role,
                 "target_org": self.warning.target_org if self.warning.target_org else None,

--- a/src/modules/update_warning/app/update_warning_viewmodel.py
+++ b/src/modules/update_warning/app/update_warning_viewmodel.py
@@ -1,0 +1,21 @@
+from src.shared.domain.entities.warning import Warning
+
+class UpdateWarningViewmodel:
+    def __init__(self, warning: Warning):
+        self.warning = warning
+
+    def to_dict(self):
+        return {
+            "updated_warning": {
+                "warning_id": self.warning.warning_id,
+                "target_role": self.warning.target_role,
+                "target_org": self.warning.target_org if self.warning.target_org else None,
+                "body": {
+                    "title": self.warning.body.title,
+                    "description": self.warning.body.description,
+                    "expire": self.warning.body.expire,
+                },
+                "created_at": self.warning.created_at,
+            },
+            "message": "the warning was created successfully"
+        }

--- a/src/modules/update_warning/app/update_warning_viewmodel.py
+++ b/src/modules/update_warning/app/update_warning_viewmodel.py
@@ -6,7 +6,7 @@ class UpdateWarningViewmodel:
 
     def to_dict(self):
         return {
-            "updated_warning": {
+            "updated-warning": {
                 "warning_id": self.warning.warning_id,
                 "target_role": self.warning.target_role,
                 "target_org": self.warning.target_org if self.warning.target_org else None,

--- a/src/modules/update_warning/app/update_warning_viewmodel.py
+++ b/src/modules/update_warning/app/update_warning_viewmodel.py
@@ -17,5 +17,5 @@ class UpdateWarningViewmodel:
                 },
                 "created_at": self.warning.created_at,
             },
-            "message": "the warning was created successfully"
+            "message": "the warning was updated successfully"
         }

--- a/src/shared/infra/external/postgres/datasources/postgres_datasource_tests.py
+++ b/src/shared/infra/external/postgres/datasources/postgres_datasource_tests.py
@@ -1,4 +1,5 @@
-import psycopg
+import psycopg2
+import psycopg2.extras
 from typing import Optional, Dict, Any, List, Generator
 import re
 from contextlib import contextmanager
@@ -19,7 +20,7 @@ class TestsRdsDatasource:
             "host": "localhost",
             "port": "5432"
         }
-        self.conn = psycopg.connect(**self.connection_params)
+        self.conn = psycopg2.connect(**self.connection_params)
         self._in_transaction = False
 
     @staticmethod
@@ -46,7 +47,7 @@ class TestsRdsDatasource:
         query_psycopg2 = self._translate_query(sql)
         
         try:
-            with self.conn.cursor(row_factory=psycopg.rows.dict_row) as cursor:
+            with self.conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cursor:
                 cursor.execute(query_psycopg2, params)
                 
                 results = []
@@ -108,7 +109,7 @@ class TestsRdsDatasource:
         
         try:
             with self.conn.cursor() as cursor:
-                psycopg.extras.execute_batch(cursor, query_psycopg2, params_list)
+                psycopg2.extras.execute_batch(cursor, query_psycopg2, params_list)
                 rowcount = cursor.rowcount
 
                 if not self._in_transaction:

--- a/src/shared/infra/external/postgres/datasources/postgres_datasource_tests.py
+++ b/src/shared/infra/external/postgres/datasources/postgres_datasource_tests.py
@@ -1,5 +1,4 @@
-import psycopg2
-import psycopg2.extras
+import psycopg
 from typing import Optional, Dict, Any, List, Generator
 import re
 from contextlib import contextmanager
@@ -20,7 +19,7 @@ class TestsRdsDatasource:
             "host": "localhost",
             "port": "5432"
         }
-        self.conn = psycopg2.connect(**self.connection_params)
+        self.conn = psycopg.connect(**self.connection_params)
         self._in_transaction = False
 
     @staticmethod
@@ -47,7 +46,7 @@ class TestsRdsDatasource:
         query_psycopg2 = self._translate_query(sql)
         
         try:
-            with self.conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cursor:
+            with self.conn.cursor(row_factory=psycopg.rows.dict_row) as cursor:
                 cursor.execute(query_psycopg2, params)
                 
                 results = []
@@ -109,7 +108,7 @@ class TestsRdsDatasource:
         
         try:
             with self.conn.cursor() as cursor:
-                psycopg2.extras.execute_batch(cursor, query_psycopg2, params_list)
+                psycopg.extras.execute_batch(cursor, query_psycopg2, params_list)
                 rowcount = cursor.rowcount
 
                 if not self._in_transaction:

--- a/src/shared/infra/repositories/load_user_mock_to_postgres.py
+++ b/src/shared/infra/repositories/load_user_mock_to_postgres.py
@@ -1,4 +1,4 @@
-import psycopg2
+import psycopg
 import os
 from src.shared.infra.repositories.user_repository_mock import UserRepositoryMock
 from src.shared.environments import Environments
@@ -6,7 +6,7 @@ from src.shared.environments import Environments
 def get_local_db_connection():
     """Função centralizada para obter uma conexão com o banco"""
     envs = Environments.get_envs()
-    return psycopg2.connect(
+    return psycopg.connect(
         dbname=envs.db_name,
         user=envs.db_local_user, 
         password=envs.db_local_pass,
@@ -81,7 +81,7 @@ if __name__ == '__main__':
         conn.commit()
         cursor.close()
         
-    except psycopg2.OperationalError as e:
+    except psycopg.OperationalError as e:
         print(f"Connection error: {e}. Please check if the PostgreSQL container is running.")
     except Exception as e:
         print(f"An unexpected error occurred: {e}")

--- a/src/shared/infra/repositories/load_user_mock_to_postgres.py
+++ b/src/shared/infra/repositories/load_user_mock_to_postgres.py
@@ -1,4 +1,4 @@
-import psycopg
+import psycopg2
 import os
 from src.shared.infra.repositories.user_repository_mock import UserRepositoryMock
 from src.shared.environments import Environments
@@ -6,7 +6,7 @@ from src.shared.environments import Environments
 def get_local_db_connection():
     """Função centralizada para obter uma conexão com o banco"""
     envs = Environments.get_envs()
-    return psycopg.connect(
+    return psycopg2.connect(
         dbname=envs.db_name,
         user=envs.db_local_user, 
         password=envs.db_local_pass,
@@ -81,7 +81,7 @@ if __name__ == '__main__':
         conn.commit()
         cursor.close()
         
-    except psycopg.OperationalError as e:
+    except psycopg2.OperationalError as e:
         print(f"Connection error: {e}. Please check if the PostgreSQL container is running.")
     except Exception as e:
         print(f"An unexpected error occurred: {e}")

--- a/src/shared/infra/repositories/load_warning_mock_to_postgres.py
+++ b/src/shared/infra/repositories/load_warning_mock_to_postgres.py
@@ -1,4 +1,4 @@
-import psycopg
+import psycopg2
 import os
 from src.shared.infra.repositories.warning_repository_mock import WarningRepositoryMock
 from src.shared.environments import Environments
@@ -6,7 +6,7 @@ from src.shared.environments import Environments
 def get_local_db_connection():
     """Função centralizada para obter uma conexão com o banco"""
     envs = Environments.get_envs()
-    return psycopg.connect(
+    return psycopg2.connect(
         dbname=envs.db_name,
         user=envs.db_local_user, 
         password=envs.db_local_pass,
@@ -95,7 +95,7 @@ if __name__ == '__main__':
         conn.commit()
         cursor.close()
         
-    except psycopg.OperationalError as e:
+    except psycopg2.OperationalError as e:
         print(f"Connection error: {e}. Please check if the PostgreSQL container is running.")
     except Exception as e:
         print(f"An unexpected error occurred: {e}")

--- a/src/shared/infra/repositories/load_warning_mock_to_postgres.py
+++ b/src/shared/infra/repositories/load_warning_mock_to_postgres.py
@@ -1,4 +1,4 @@
-import psycopg2
+import psycopg
 import os
 from src.shared.infra.repositories.warning_repository_mock import WarningRepositoryMock
 from src.shared.environments import Environments
@@ -6,7 +6,7 @@ from src.shared.environments import Environments
 def get_local_db_connection():
     """Função centralizada para obter uma conexão com o banco"""
     envs = Environments.get_envs()
-    return psycopg2.connect(
+    return psycopg.connect(
         dbname=envs.db_name,
         user=envs.db_local_user, 
         password=envs.db_local_pass,
@@ -95,7 +95,7 @@ if __name__ == '__main__':
         conn.commit()
         cursor.close()
         
-    except psycopg2.OperationalError as e:
+    except psycopg.OperationalError as e:
         print(f"Connection error: {e}. Please check if the PostgreSQL container is running.")
     except Exception as e:
         print(f"An unexpected error occurred: {e}")

--- a/src/shared/infra/repositories/warning_repository_mock.py
+++ b/src/shared/infra/repositories/warning_repository_mock.py
@@ -67,25 +67,24 @@ class WarningRepositoryMock(IWarningRepository):
         
         return new_warning
     
-    def update_warning(self, warning: Warning) -> Optional[Warning]:
+    def update_warning(self, warning_id: str, new_warning: Warning) -> Optional[Warning]:
         
-        warning_found = False
-        
+        found = False
         for i, existing_warning in enumerate(self.warnings):
             
-            if existing_warning.warning_id == warning.warning_id:
+            if existing_warning.warning_id == warning_id:
                 
-                self.warnings[i] = warning
+                self.warnings[i] = new_warning
                 
-                warning_found = True
+                found = True
                 
                 break
-        
-        if not warning_found:
+
+        if not found:
             
-            raise NoItemsFound(warning.warning_id)
+            raise NoItemsFound(warning_id)
         
-        return warning
+        return new_warning
     
     def delete_warning(self, warning_id: str) -> Optional[Warning]:
         

--- a/tests/modules/create_warning/app/test_create_warning_controller.py
+++ b/tests/modules/create_warning/app/test_create_warning_controller.py
@@ -39,7 +39,7 @@ class Test_CreateWarningController:
         assert response.status_code == 400
         assert response.body == 'Field new_warning is missing'
     
-    def test_create_warning_controller_with_specif_warning_and_as_admin(self):
+    def test_create_warning_controller_with_specific_warning_and_as_admin(self):
         repo = WarningRepositoryMock()
         user_repo= UserRepositoryMock()
         usecase= CreateWarningUsecase(repo=repo, user_repo=user_repo)

--- a/tests/modules/update_warning/app/test_update_warning_controller.py
+++ b/tests/modules/update_warning/app/test_update_warning_controller.py
@@ -1,0 +1,137 @@
+from src.modules.update_warning.app.update_warning_controller import UpdateWarningController
+from src.modules.update_warning.app.update_warning_usecase import UpdateWarningUsecase
+from src.shared.domain.enums.role_enum import ROLE
+from src.shared.domain.enums.organization_enum import ORGANIZATION
+from src.shared.helpers.external_interfaces.http_models import HttpRequest
+from src.shared.infra.repositories.user_repository_mock import UserRepositoryMock
+from src.shared.infra.repositories.warning_repository_mock import WarningRepositoryMock
+from src.shared.domain.entities.warning import Warning, WarningBody
+
+
+class Test_UpdateWarningController:
+    def test_update_warning_controller_without_user_from_authorizer(self):
+        repo = WarningRepositoryMock()
+        user_repo= UserRepositoryMock()
+        usecase= UpdateWarningUsecase(repo=repo, user_repo=user_repo)
+        controller= UpdateWarningController(usecase=usecase)
+
+        request = HttpRequest()
+
+        response = controller(request=request)
+
+        assert response.status_code == 400
+        assert response.body == 'Field user_from_authorizer is missing'
+
+    def test_update_warning_controller_without_warning_id(self):
+        repo = WarningRepositoryMock()
+        user_repo= UserRepositoryMock()
+        usecase= UpdateWarningUsecase(repo=repo, user_repo=user_repo)
+        controller= UpdateWarningController(usecase=usecase)
+
+        request = HttpRequest(body={
+            'user_from_authorizer':{
+                'id': '550e8400-e29b-41d4-a716-446655440001',
+                'displayName': 'João',
+                'mail': '21.00678-2@maua.br',
+            },
+            'update_warning':{
+                'updated_warning':{
+                    'title': 'Atualização de sistema - versão 2',
+                    'description': 'O sistema será atualizado no próximo fim de semana. Esta é a versão 2.',
+                },
+            }
+        })
+
+        response= controller(request=request)
+        assert response.status_code == 400
+        assert response.body == 'Field warning_id is missing'
+
+    def test_update_warning_controller_with_specific_warning_and_as_admin(self):
+        repo = WarningRepositoryMock()
+        user_repo= UserRepositoryMock()
+        usecase= UpdateWarningUsecase(repo=repo, user_repo=user_repo)
+        controller= UpdateWarningController(usecase=usecase)
+
+        new_warning: Warning = Warning(
+            target_role=ROLE.USER,
+            target_org=ORGANIZATION.DEV,
+            body=WarningBody(
+                title='Atualização de sistema',
+                description='O sistema será atualizado no próximo fim de semana.',
+                expire=1704067200000
+            ),
+            created_at=1672531200000
+        )
+
+        warning = usecase.repo.create_warning(new_warning)
+
+        request = HttpRequest(body={
+            'user_from_authorizer':{
+                'id': '550e8400-e29b-41d4-a716-446655440001',
+                'displayName': 'João',
+                'mail': '21.00678-2@maua.br',
+            },
+            'update_warning':{
+                'warning_id': warning.warning_id,
+                'updated_warning':{
+                    'title': 'Atualização de sistema - versão 2',
+                    'description': 'O sistema será atualizado no próximo fim de semana. Esta é a versão 2.',
+                },
+            }
+        })
+
+        response= controller(request=request)
+        assert response.status_code == 200
+        assert response.body["updated_warning"]['warning_id'] == warning.warning_id
+        assert response.body["updated_warning"]['body']['title'] == 'Atualização de sistema - versão 2'
+        assert response.body["updated_warning"]['body']['description'] == 'O sistema será atualizado no próximo fim de semana. Esta é a versão 2.'
+
+    def test_update_warning_controller_with_nonexistent_warning_id(self):
+        repo = WarningRepositoryMock()
+        user_repo= UserRepositoryMock()
+        usecase= UpdateWarningUsecase(repo=repo, user_repo=user_repo)
+        controller= UpdateWarningController(usecase=usecase)
+
+        request = HttpRequest(body={
+            'user_from_authorizer':{
+                'id': '550e8400-e29b-41d4-a716-446655440001',
+                'displayName': 'João',
+                'mail': '21.00678-2@maua.br',
+            },
+            'update_warning':{
+                'warning_id': 'nonexistent-warning-id',
+                'updated_warning':{
+                    'title': 'Atualização de sistema - versão 2',
+                    'description': 'O sistema será atualizado no próximo fim de semana. Esta é a versão 2.',
+                },
+            }
+        })
+
+        response= controller(request=request)
+        assert response.status_code == 404
+        assert response.body == 'No items found for nonexistent-warning-id'
+
+    def test_update_warning_controller_with_insufficient_permissions(self):
+        repo = WarningRepositoryMock()
+        user_repo= UserRepositoryMock()
+        usecase= UpdateWarningUsecase(repo=repo, user_repo=user_repo)
+        controller= UpdateWarningController(usecase=usecase)
+
+        request = HttpRequest(body={
+            'user_from_authorizer':{
+                'id': '550e8400-e29b-41d4-a716-446655440002',
+                'displayName': 'Maria',
+                'mail': '22.00678-2@maua.br',
+            },
+            'update_warning':{
+                'warning_id': 'some-warning-id',
+                'updated_warning':{
+                    'title': 'Atualização de sistema - versão 2',
+                    'description': 'O sistema será atualizado no próximo fim de semana. Esta é a versão 2.',
+                },
+            }
+        })
+
+        response= controller(request=request)
+        assert response.status_code == 403
+        assert response.body == 'Only ADM users can update warnings.'

--- a/tests/modules/update_warning/app/test_update_warning_presenter.py
+++ b/tests/modules/update_warning/app/test_update_warning_presenter.py
@@ -1,0 +1,196 @@
+import json
+
+from src.modules.update_warning.app.update_warning_presenter import lambda_handler
+
+
+class Test_UpdateWarningPresenter:
+
+    def test_update_warning_general_presenter(self):
+        event = {
+            "version": "2.0",
+            "routeKey": "$default",
+            "rawPath": "/my/path",
+            "rawQueryString": "parameter1=value1&parameter1=value2&parameter2=value",
+            "cookies": [
+                "cookie1",
+                "cookie2"
+            ],
+            "headers": {
+                "header1": "value1",
+                "header2": "value1,value2"
+            },
+            "queryStringParameters": {
+                "parameter1": "1"
+            },
+            "requestContext": {
+                "accountId": "123456789012",
+                "apiId": "<urlid>",
+                "authentication": None,
+                "authorizer": {
+                    "user": {
+                        "id": "550e8400-e29b-41d4-a716-446655440001",
+                        "displayName": "João", 
+                        "mail": "21.00678-2@maua.br"
+                    }
+                },
+                "domainName": "<url-id>.lambda-url.us-west-2.on.aws",
+                "domainPrefix": "<url-id>",
+                "external_interfaces": {
+                    "method": "POST",
+                    "path": "/my/path",
+                    "protocol": "HTTP/1.1",
+                    "sourceIp": "123.123.123.123",
+                    "userAgent": "agent"
+                },
+                "requestId": "id",
+                "routeKey": "$default",
+                "stage": "$default",
+                "time": "12/Mar/2020:19:03:58 +0000",
+                "timeEpoch": 1583348638390
+            },
+            "body": json.dumps({
+                "update_warning": {
+                    "warning_id": "e6112d17-c030-4d65-8b9f-e472d20055a5",
+                    "updated_warning": {
+                        "title": "General Warning",
+                        "description": "This is a general warning for all organizations"
+                    }
+                }
+            }),
+            "pathParameters": None,
+            "isBase64Encoded": None,
+            "stageVariables": None
+        }
+
+        response = lambda_handler(event, None)
+
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+
+        assert body["updated_warning"]["warning_id"] == "e6112d17-c030-4d65-8b9f-e472d20055a5"
+        assert body["updated_warning"]["body"]["title"] == "General Warning"
+        assert body["updated_warning"]["body"]["description"] == "This is a general warning for all organizations"
+
+    def test_update_warning_presenter_with_nonexistent_warning_id(self):
+        event = {
+            "version": "2.0",
+            "routeKey": "$default",
+            "rawPath": "/my/path",
+            "rawQueryString": "parameter1=value1&parameter1=value2&parameter2=value",
+            "cookies": [
+                "cookie1",
+                "cookie2"
+            ],
+            "headers": {
+                "header1": "value1",
+                "header2": "value1,value2"
+            },
+            "queryStringParameters": {
+                "parameter1": "1"
+            },
+            "requestContext": {
+                "accountId": "123456789012",
+                "apiId": "<urlid>",
+                "authentication": None,
+                "authorizer": {
+                    "user": {
+                        "id": "550e8400-e29b-41d4-a716-446655440001",
+                        "displayName": "João", 
+                        "mail": "21.00678-2@maua.br"
+                    }
+                },
+                "domainName": "<url-id>.lambda-url.us-west-2.on.aws",
+                "domainPrefix": "<url-id>",
+                "external_interfaces": {
+                    "method": "POST",
+                    "path": "/my/path",
+                    "protocol": "HTTP/1.1",
+                    "sourceIp": "123.123.123.123",
+                    "userAgent": "agent"
+                },
+                "requestId": "id",
+                "routeKey": "$default",
+                "stage": "$default",
+                "time": "12/Mar/2020:19:03:58 +0000",
+                "timeEpoch": 1583348638390
+            },
+            "body": json.dumps({
+                "update_warning": {
+                    "warning_id": "invalid",
+                    "updated_warning": {
+                        "title": "General Warning",
+                        "description": "This is a general warning for all organizations"
+                    }
+                }
+            }),
+            "pathParameters": None,
+            "isBase64Encoded": None,
+            "stageVariables": None
+        }
+
+        response = lambda_handler(event, None)
+
+        assert response["statusCode"] == 404
+        assert response["body"] == '"No items found for invalid"'
+
+    def test_update_warning_presenter_with_insufficient_permissions(self):
+        event = {
+            "version": "2.0",
+            "routeKey": "$default",
+            "rawPath": "/my/path",
+            "rawQueryString": "parameter1=value1&parameter1=value2&parameter2=value",
+            "cookies": [
+                "cookie1",
+                "cookie2"
+            ],
+            "headers": {
+                "header1": "value1",
+                "header2": "value1,value2"
+            },
+            "queryStringParameters": {
+                "parameter1": "1"
+            },
+            "requestContext": {
+                "accountId": "123456789012",
+                "apiId": "<urlid>",
+                "authentication": None,
+                "authorizer": {
+                    "user": {
+                        "id": "550e8400-e29b-41d4-a716-446655440002",
+                        "displayName": "Maria", 
+                        "mail": "22.00678-2@maua.br"
+                    }
+                },
+                "domainName": "<url-id>.lambda-url.us-west-2.on.aws",
+                "domainPrefix": "<url-id>",
+                "external_interfaces": {
+                    "method": "POST",
+                    "path": "/my/path",
+                    "protocol": "HTTP/1.1",
+                    "sourceIp": "123.123.123.123",
+                    "userAgent": "agent"
+                },
+                "requestId": "id",
+                "routeKey": "$default",
+                "stage": "$default",
+                "time": "12/Mar/2020:19:03:58 +0000",
+                "timeEpoch": 1583348638390
+            },
+            "body": json.dumps({
+                "update_warning": {
+                    "warning_id": "e6112d17-c030-4d65-8b9f-e472d20055a5",
+                    "updated_warning": {
+                        "title": "General Warning",
+                        "description": "This is a general warning for all organizations"
+                    }
+                }
+            }),
+            "pathParameters": None,
+            "isBase64Encoded": None,
+            "stageVariables": None
+        }
+
+        response = lambda_handler(event, None)
+
+        assert response["statusCode"] == 403
+        assert response["body"] == '"Only ADM users can update warnings."'

--- a/tests/modules/update_warning/app/test_update_warning_usecase.py
+++ b/tests/modules/update_warning/app/test_update_warning_usecase.py
@@ -1,0 +1,83 @@
+import pytest
+from src.modules.update_warning.app.update_warning_usecase import UpdateWarningUsecase
+from src.shared.domain.entities.warning import Warning, WarningBody
+from src.shared.domain.enums.organization_enum import ORGANIZATION
+from src.shared.domain.enums.role_enum import ROLE
+from src.shared.helpers.errors.usecase_errors import ForbiddenAction
+from src.shared.infra.repositories.user_repository_mock import UserRepositoryMock
+from src.shared.infra.repositories.warning_repository_mock import WarningRepositoryMock
+
+
+class Test_UpdateWarningUsecase:
+    def test_update_warning_usecase_as_non_admin(self):
+        repo = WarningRepositoryMock()
+        user_repo = UserRepositoryMock()
+        usecase = UpdateWarningUsecase(repo=repo, user_repo=user_repo)
+
+        new_warning: Warning = Warning(
+            target_role=ROLE.USER,
+            target_org=ORGANIZATION.DEV,
+            body=WarningBody(
+                title='Atualização de sistema',
+                description='O sistema será atualizado no próximo fim de semana.',
+                expire=1704067200000
+            ),
+            created_at=1672531200000
+        )
+
+        warning = usecase.repo.create_warning(new_warning)
+
+        with pytest.raises(ForbiddenAction) as exc_info:
+            usecase(
+                warning_id=warning.warning_id,
+                title='Atualização de sistema - versão 2',
+                description='O sistema será atualizado no próximo fim de semana. Esta é a versão 2.',
+                user_id='550e8400-e29b-41d4-a716-446655440002'  # Non-admin user
+            )
+
+        assert str(exc_info.value) == 'Only ADM users can update warnings.'
+
+    def test_update_warning_usecase_as_admin(self):
+        repo = WarningRepositoryMock()
+        user_repo = UserRepositoryMock()
+        usecase = UpdateWarningUsecase(repo=repo, user_repo=user_repo)
+
+        new_warning: Warning = Warning(
+            target_role=ROLE.USER,
+            target_org=ORGANIZATION.DEV,
+            body=WarningBody(
+                title='Atualização de sistema',
+                description='O sistema será atualizado no próximo fim de semana.',
+                expire=1704067200000
+            ),
+            created_at=1672531200000
+        )
+
+        warning = usecase.repo.create_warning(new_warning)
+
+        updated_warning = usecase(
+            warning_id=warning.warning_id,
+            title='Atualização de sistema - versão 2',
+            description='O sistema será atualizado no próximo fim de semana. Esta é a versão 2.',
+            user_id='550e8400-e29b-41d4-a716-446655440001'  # Admin user
+        )
+
+        assert updated_warning.body.title == 'Atualização de sistema - versão 2'
+        assert updated_warning.body.description == 'O sistema será atualizado no próximo fim de semana. Esta é a versão 2.'
+        assert updated_warning.target_role == 'USER'
+        assert updated_warning.target_org == 'DEV'
+
+    def test_update_warning_usecase_with_nonexistent_warning_id(self):
+        repo = WarningRepositoryMock()
+        user_repo = UserRepositoryMock()
+        usecase = UpdateWarningUsecase(repo=repo, user_repo=user_repo)
+
+        with pytest.raises(Exception) as exc_info:
+            usecase(
+                warning_id='nonexistent-warning-id',
+                title='Atualização de sistema - versão 2',
+                description='O sistema será atualizado no próximo fim de semana. Esta é a versão 2.',
+                user_id='550e8400-e29b-41d4-a716-446655440001'  # Admin user
+            )
+
+        assert str(exc_info.value) == 'No items found for nonexistent-warning-id'

--- a/tests/modules/update_warning/app/test_update_warning_viewmodel.py
+++ b/tests/modules/update_warning/app/test_update_warning_viewmodel.py
@@ -1,0 +1,85 @@
+from datetime import datetime
+from src.modules.update_warning.app.update_warning_viewmodel import UpdateWarningViewmodel
+from src.shared.domain.entities.warning import Warning, WarningBody
+from src.shared.domain.enums.role_enum import ROLE
+
+
+class Test_UpdateWarningViewmodel:
+    def test_update_warning_viewmodel_general(self):
+        warning = Warning(
+            warning_id="e6112d17-c030-4d65-8b9f-e472d20055a5",
+            target_role=ROLE.USER,
+            body=WarningBody(
+                title="General Warning",
+                description="This is a general warning for all organizations",
+                expire=int(datetime.now().replace(year=datetime.now().year + 1).timestamp() * 1000)
+            ),
+            created_at=int(datetime(2025, 11, 28, 10, 0, 0).timestamp() * 1000)
+        )
+
+        warning_viewmodel = UpdateWarningViewmodel(warning=warning)
+
+        assert warning_viewmodel.warning == warning
+
+    def test_update_warning_viewmodel_to_dict(self):
+        warning = Warning(
+            warning_id="f7223e28-d141-5e76-9a0f-f573e31166b6",
+            target_role=ROLE.PRESIDENT,
+            target_org="NAWAT",
+            body=WarningBody(
+                title="NAWAT Warning",
+                description="Important update for NAWAT organization",
+                expire=int(datetime.now().replace(year=datetime.now().year + 1).timestamp() * 1000)
+            ),
+            created_at=int(datetime(2025, 11, 28, 10, 0, 0).timestamp() * 1000)
+        )
+
+        warning_viewmodel = UpdateWarningViewmodel(warning=warning)
+
+        result = warning_viewmodel.to_dict()
+
+        assert result == {
+            "updated_warning": {
+                "warning_id": "f7223e28-d141-5e76-9a0f-f573e31166b6",
+                "target_role": "PRESIDENT",
+                "target_org": "NAWAT",
+                "body": {
+                    "title": "NAWAT Warning",
+                    "description": "Important update for NAWAT organization",
+                    "expire": warning.body.expire
+                },
+                "created_at": warning.created_at
+            },
+            "message": "the warning was updated successfully"
+        }
+
+    def test_update_warning_viewmodel_to_dict_no_target_org(self):
+        warning = Warning(
+            warning_id="a8334f39-e252-6f87-0b1g-g684f42277c7",
+            target_role=ROLE.USER,
+            body=WarningBody(
+                title="System Update",
+                description="The system will be updated this weekend.",
+                expire=int(datetime.now().replace(year=datetime.now().year + 1).timestamp() * 1000)
+            ),
+            created_at=int(datetime(2025, 11, 28, 10, 0, 0).timestamp() * 1000)
+        )
+
+        warning_viewmodel = UpdateWarningViewmodel(warning=warning)
+
+        result = warning_viewmodel.to_dict()
+
+        assert result == {
+            "updated_warning": {
+                "warning_id": "a8334f39-e252-6f87-0b1g-g684f42277c7",
+                "target_role": "USER",
+                "target_org": None,
+                "body": {
+                    "title": "System Update",
+                    "description": "The system will be updated this weekend.",
+                    "expire": warning.body.expire
+                },
+                "created_at": warning.created_at
+            },
+            "message": "the warning was updated successfully"
+        }

--- a/tests/shared/infra/repositories/test_warning_repository_mock.py
+++ b/tests/shared/infra/repositories/test_warning_repository_mock.py
@@ -46,7 +46,7 @@ class TestWarningRepositoryMock:
             created_at=previous_warning.created_at
         )
         
-        warning = repo.update_warning(warning=updated_warning)
+        warning = repo.update_warning(warning_id=warning_id, new_warning=updated_warning)
         
         assert warning == updated_warning
         assert updated_warning != previous_warning


### PR DESCRIPTION
This pull request introduces the update_warning functionality, which accepts two arguments:
- **warning_id**: The identifier of the warning the administrator intends to update.
- **updated_warning**: The new warning object _(this object may omit certain parameters if they are not intended to be modified)._

Additionally, unit tests have been added for each functionality.